### PR TITLE
- 'sisteAvsluttendeKalenderMåned' is part of inntekt response, replac…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ val orgJsonVersion = "20180813"
 dependencies {
     implementation(kotlin("stdlib"))
     implementation("com.github.navikt:dagpenger-streams:2019.05.21-14.30.a7af5e9d49fe")
-    implementation("com.github.navikt:dagpenger-events:2019.05.20-11.56.33cd4c73a439")
+    implementation("com.github.navikt:dagpenger-events:2019.05.28-13.44.ab5008b3ee50")
 
     implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
 

--- a/src/main/kotlin/no/nav/dagpenger/regel/minsteinntekt/Fakta.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/minsteinntekt/Fakta.kt
@@ -5,22 +5,20 @@ import no.nav.dagpenger.events.inntekt.v1.InntektKlasse
 import no.nav.dagpenger.events.inntekt.v1.all
 import no.nav.dagpenger.events.inntekt.v1.sumInntekt
 import java.math.BigDecimal
-import java.time.YearMonth
 
 data class Fakta(
     val inntekt: Inntekt,
-    val senesteInntektsMåned: YearMonth,
     val bruktInntektsPeriode: InntektsPeriode? = null,
     val verneplikt: Boolean,
     val fangstOgFisk: Boolean,
     val grunnbeløp: BigDecimal = BigDecimal(96883)
 ) {
-    val inntektsPerioder = inntekt.splitIntoInntektsPerioder(senesteInntektsMåned)
+    val inntektsPerioder = inntekt.splitIntoInntektsPerioder()
 
     val inntektsPerioderUtenBruktInntekt = if (bruktInntektsPeriode == null) inntektsPerioder else inntekt.filterPeriod(
         bruktInntektsPeriode.førsteMåned,
         bruktInntektsPeriode.sisteMåned
-    ).splitIntoInntektsPerioder(senesteInntektsMåned)
+    ).splitIntoInntektsPerioder()
 
     val arbeidsinntektSiste12: BigDecimal = inntektsPerioderUtenBruktInntekt.first.sumInntekt(listOf(InntektKlasse.ARBEIDSINNTEKT))
     val arbeidsinntektSiste36: BigDecimal = inntektsPerioderUtenBruktInntekt.all().sumInntekt(listOf(InntektKlasse.ARBEIDSINNTEKT))

--- a/src/main/kotlin/no/nav/dagpenger/regel/minsteinntekt/Minsteinntekt.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/minsteinntekt/Minsteinntekt.kt
@@ -33,7 +33,6 @@ class Minsteinntekt(private val env: Environment) : River() {
         const val MINSTEINNTEKT_INNTEKTSPERIODER = "minsteinntektInntektsPerioder"
         const val INNTEKT = "inntektV1"
         const val AVTJENT_VERNEPLIKT = "harAvtjentVerneplikt"
-        const val SENESTE_INNTEKTSMÅNED = "senesteInntektsmåned"
         const val BRUKT_INNTEKTSPERIODE = "bruktInntektsPeriode"
         const val FANGST_OG_FISK = "oppfyllerKravTilFangstOgFisk"
     }

--- a/src/main/kotlin/no/nav/dagpenger/regel/minsteinntekt/Minsteinntekt.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/minsteinntekt/Minsteinntekt.kt
@@ -47,8 +47,7 @@ class Minsteinntekt(private val env: Environment) : River() {
     override fun filterPredicates(): List<Predicate<String, Packet>> {
         return listOf(
             Predicate { _, packet -> !packet.hasField(MINSTEINNTEKT_RESULTAT) },
-            Predicate { _, packet -> packet.hasField(INNTEKT) },
-            Predicate { _, packet -> packet.hasField(SENESTE_INNTEKTSMÅNED) }
+            Predicate { _, packet -> packet.hasField(INNTEKT) }
         )
     }
 

--- a/src/main/kotlin/no/nav/dagpenger/regel/minsteinntekt/PacketToFakta.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/minsteinntekt/PacketToFakta.kt
@@ -11,10 +11,9 @@ internal fun packetToFakta(packet: Packet): Fakta {
     val inntekt: Inntekt =
         packet.getObjectValue(Minsteinntekt.INNTEKT) { serialized -> checkNotNull(jsonAdapterInntekt.fromJsonValue(serialized)) }
     val avtjentVernePlikt = packet.getNullableBoolean(Minsteinntekt.AVTJENT_VERNEPLIKT) ?: false
-    val senesteInntektsMåned = packet.getYearMonth(Minsteinntekt.SENESTE_INNTEKTSMÅNED)
     val bruktInntektsPeriode =
         packet.getNullableObjectValue(Minsteinntekt.BRUKT_INNTEKTSPERIODE, bruktInntektsPeriodeAdapter::fromJsonValue)
     val fangstOgFisk = packet.getNullableBoolean(Minsteinntekt.FANGST_OG_FISK) ?: false
 
-    return Fakta(inntekt, senesteInntektsMåned, bruktInntektsPeriode, avtjentVernePlikt, fangstOgFisk)
+    return Fakta(inntekt, bruktInntektsPeriode, avtjentVernePlikt, fangstOgFisk)
 }

--- a/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/CreateInntektPerioderTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/CreateInntektPerioderTest.kt
@@ -13,11 +13,16 @@ class CreateInntektPerioderTest {
 
     @Test
     fun `createInntektPerioder correctly for no inntekt`() {
-        val senesteMåned = YearMonth.of(2019, 3)
-        val fakta = Fakta(Inntekt("id", emptyList()), senesteMåned, null, false, fangstOgFisk = false)
+        val sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 3)
+        val fakta = Fakta(
+            Inntekt("id", emptyList(), sisteAvsluttendeKalenderMåned = sisteAvsluttendeKalenderMåned),
+            null,
+            false,
+            fangstOgFisk = false
+        )
 
         val inntektsPerioder = minsteinntekt.createInntektPerioder(fakta)
-        assertThreeCorrectPeriods(inntektsPerioder, senesteMåned)
+        assertThreeCorrectPeriods(inntektsPerioder, sisteAvsluttendeKalenderMåned)
 
         assertTrue(inntektsPerioder.all { it.inntekt == BigDecimal.ZERO })
         assertTrue(inntektsPerioder.all { it.andel == BigDecimal.ZERO })
@@ -26,17 +31,21 @@ class CreateInntektPerioderTest {
 
     @Test
     fun `createInntektPerioder correctly for constant arbeidsinntekt`() {
-        val senesteMåned = YearMonth.of(2019, 1)
+        val sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 1)
+        val inntektsListe = generateArbeidsinntekt(36, BigDecimal(1000), sisteAvsluttendeKalenderMåned)
         val fakta = Fakta(
-            Inntekt("id", generateArbeidsinntekt(36, BigDecimal(1000), senesteMåned)),
-            senesteMåned,
+            Inntekt(
+                "id",
+                inntektsListe,
+                sisteAvsluttendeKalenderMåned = sisteAvsluttendeKalenderMåned
+            ),
             null,
             false,
             fangstOgFisk = false
         )
 
         val inntektsPerioder = minsteinntekt.createInntektPerioder(fakta)
-        assertThreeCorrectPeriods(inntektsPerioder, senesteMåned)
+        assertThreeCorrectPeriods(inntektsPerioder, sisteAvsluttendeKalenderMåned)
 
         assertTrue(inntektsPerioder.all { it.inntekt == BigDecimal(12000) })
         assertTrue(inntektsPerioder.all { it.andel == BigDecimal(12000) })
@@ -45,16 +54,23 @@ class CreateInntektPerioderTest {
 
     @Test
     fun `createInntektPerioder correctly for inntekt with both types when fangstOgFiske=false`() {
-        val senesteMåned = YearMonth.of(2019, 1)
+        val sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 1)
+        val inntektsListe = generateArbeidsOgFangstOgFiskInntekt(
+            36,
+            BigDecimal(2000),
+            BigDecimal(2000),
+            sisteAvsluttendeKalenderMåned
+        )
         val fakta = Fakta(
             Inntekt(
                 "id",
-                generateArbeidsOgFangstOgFiskInntekt(36, BigDecimal(2000), BigDecimal(2000), senesteMåned)
-            ), senesteMåned, null, false, fangstOgFisk = false
+                inntektsListe,
+                sisteAvsluttendeKalenderMåned = sisteAvsluttendeKalenderMåned
+            ), null, false, fangstOgFisk = false
         )
 
         val inntektsPerioder = minsteinntekt.createInntektPerioder(fakta)
-        assertThreeCorrectPeriods(inntektsPerioder, senesteMåned)
+        assertThreeCorrectPeriods(inntektsPerioder, sisteAvsluttendeKalenderMåned)
 
         assertTrue(inntektsPerioder.all { it.inntekt == BigDecimal(24000) })
         assertTrue(inntektsPerioder.all { it.andel == BigDecimal(24000) })
@@ -63,16 +79,19 @@ class CreateInntektPerioderTest {
 
     @Test
     fun `createInntektPerioder correctly for inntekt with both types when fangstOgFiske=true`() {
-        val senesteMåned = YearMonth.of(2019, 1)
+        val sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 1)
+        val inntektsListe =
+            generateArbeidsOgFangstOgFiskInntekt(36, BigDecimal(2000), BigDecimal(2000), sisteAvsluttendeKalenderMåned)
         val fakta = Fakta(
             Inntekt(
                 "id",
-                generateArbeidsOgFangstOgFiskInntekt(36, BigDecimal(2000), BigDecimal(2000), senesteMåned)
-            ), senesteMåned, null, false, fangstOgFisk = true
+                inntektsListe,
+                sisteAvsluttendeKalenderMåned = sisteAvsluttendeKalenderMåned
+            ), null, false, fangstOgFisk = true
         )
 
         val inntektsPerioder = minsteinntekt.createInntektPerioder(fakta)
-        assertThreeCorrectPeriods(inntektsPerioder, senesteMåned)
+        assertThreeCorrectPeriods(inntektsPerioder, sisteAvsluttendeKalenderMåned)
 
         assertTrue(inntektsPerioder.all { it.inntekt == BigDecimal(48000) })
         assertTrue(inntektsPerioder.all { it.andel == BigDecimal(48000) })
@@ -81,17 +100,17 @@ class CreateInntektPerioderTest {
 
     @Test
     fun `createInntektPerioder correctly for constant fangstogfiskeinntekt`() {
-        val senesteMåned = YearMonth.of(2019, 1)
+        val sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 1)
+        val inntektsListe = generateFangstOgFiskInntekt(36, BigDecimal(2000), sisteAvsluttendeKalenderMåned)
         val fakta = Fakta(
-            Inntekt("id", generateFangstOgFiskInntekt(36, BigDecimal(2000), senesteMåned)),
-            senesteMåned,
+            Inntekt("id", inntektsListe, sisteAvsluttendeKalenderMåned = sisteAvsluttendeKalenderMåned),
             null,
             false,
             fangstOgFisk = true
         )
 
         val inntektsPerioder = minsteinntekt.createInntektPerioder(fakta)
-        assertThreeCorrectPeriods(inntektsPerioder, senesteMåned)
+        assertThreeCorrectPeriods(inntektsPerioder, sisteAvsluttendeKalenderMåned)
 
         assertTrue(inntektsPerioder.all { it.inntekt == BigDecimal(24000) })
         assertTrue(inntektsPerioder.all { it.andel == BigDecimal(24000) })
@@ -100,18 +119,18 @@ class CreateInntektPerioderTest {
 
     @Test
     fun `createInntektPerioder correctly excludes brukt inntekt`() {
-        val senesteMåned = YearMonth.of(2019, 3)
+        val sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 3)
 
+        val inntektsListe = generateArbeidsinntekt(36, BigDecimal(2000), sisteAvsluttendeKalenderMåned)
         val fakta = Fakta(
-            Inntekt("id", generateArbeidsinntekt(36, BigDecimal(2000), senesteMåned)),
-            senesteMåned,
+            Inntekt("id", inntektsListe, sisteAvsluttendeKalenderMåned = sisteAvsluttendeKalenderMåned),
             InntektsPeriode(YearMonth.of(2015, 1), YearMonth.of(2017, 7)),
             false,
             fangstOgFisk = false
         )
 
         val inntektsPerioder = minsteinntekt.createInntektPerioder(fakta)
-        assertThreeCorrectPeriods(inntektsPerioder, senesteMåned)
+        assertThreeCorrectPeriods(inntektsPerioder, sisteAvsluttendeKalenderMåned)
 
         assertTrue(inntektsPerioder.all { it.inntekt == BigDecimal(24000) })
         assertEquals(BigDecimal(24000), inntektsPerioder.find { it.periode == 1 }?.andel)

--- a/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/InngangsvilkårArbeidsinntektSpesifikasjonsTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/InngangsvilkårArbeidsinntektSpesifikasjonsTest.kt
@@ -16,8 +16,7 @@ internal class InngangsvilkårArbeidsinntektSpesifikasjonsTest {
     fun `Skal ikke gi rett til dagpenger i følge § 4-4 dersom du ikke har inntekt siste 12 mnd`() {
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", emptyList()),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false
@@ -34,8 +33,7 @@ internal class InngangsvilkårArbeidsinntektSpesifikasjonsTest {
         val inntekt = generateArbeidsInntekt(1..3, BigDecimal(1))
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false,
@@ -53,8 +51,7 @@ internal class InngangsvilkårArbeidsinntektSpesifikasjonsTest {
         val inntekt = generate12MånederArbeidsInntekt()
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false
@@ -69,8 +66,7 @@ internal class InngangsvilkårArbeidsinntektSpesifikasjonsTest {
     fun `Skal ikke gi rett til dagpenger i følge § 4-4 dersom du ikke har inntekt siste 36 mnd`() {
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", emptyList()),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false
@@ -87,8 +83,7 @@ internal class InngangsvilkårArbeidsinntektSpesifikasjonsTest {
         val inntekt = generateArbeidsInntekt(1..24, BigDecimal(1))
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false,
@@ -106,8 +101,7 @@ internal class InngangsvilkårArbeidsinntektSpesifikasjonsTest {
         val inntekt = generate36MånederArbeidsInntekt()
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false
@@ -124,8 +118,7 @@ internal class InngangsvilkårArbeidsinntektSpesifikasjonsTest {
         val inntekt = generateFangstOgFiske(1..12, BigDecimal(50000))
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false
@@ -142,8 +135,7 @@ internal class InngangsvilkårArbeidsinntektSpesifikasjonsTest {
         val inntekt = generateFangstOgFiske(1..36, BigDecimal(50000))
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false

--- a/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/InngangsvilkårFangstOgFiskeSpesifikasjonsTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/InngangsvilkårFangstOgFiskeSpesifikasjonsTest.kt
@@ -13,8 +13,7 @@ internal class InngangsvilkårFangstOgFiskeSpesifikasjonsTest {
     fun `Skal ikke gi rett til dagpenger i følge § 4-4 dersom du ikke har inntekt siste 12 mnd`() {
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", emptyList()),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = true
@@ -31,8 +30,7 @@ internal class InngangsvilkårFangstOgFiskeSpesifikasjonsTest {
         val inntekt = generateFangstOgFiskInntekt(3, BigDecimal(1))
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = true,
@@ -50,8 +48,7 @@ internal class InngangsvilkårFangstOgFiskeSpesifikasjonsTest {
         val inntekt = generate12MånederFangstOgFiskInntekt()
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = true
@@ -66,8 +63,7 @@ internal class InngangsvilkårFangstOgFiskeSpesifikasjonsTest {
     fun `Skal ikke gi rett til dagpenger i følge § 4-4 dersom du ikke har inntekt siste 36 mnd`() {
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", emptyList()),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = true
@@ -84,8 +80,7 @@ internal class InngangsvilkårFangstOgFiskeSpesifikasjonsTest {
         val inntekt = generateFangstOgFiskInntekt(24, BigDecimal(1))
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = true,
@@ -103,8 +98,7 @@ internal class InngangsvilkårFangstOgFiskeSpesifikasjonsTest {
         val inntekt = generate36MånederFangstOgFiskInntekt()
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = true
@@ -121,8 +115,7 @@ internal class InngangsvilkårFangstOgFiskeSpesifikasjonsTest {
         val inntekt = generateArbeidsinntekt(12, BigDecimal(50000))
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = true
@@ -139,8 +132,7 @@ internal class InngangsvilkårFangstOgFiskeSpesifikasjonsTest {
         val inntekt = generateArbeidsinntekt(36, BigDecimal(50000))
 
         val fakta = Fakta(
-            inntekt = Inntekt("123", inntekt),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", inntekt, sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false

--- a/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/InngangsvilkårVernepliktSpesifikasjonsTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/InngangsvilkårVernepliktSpesifikasjonsTest.kt
@@ -13,8 +13,7 @@ internal class InngangsvilkårVernepliktSpesifikasjonsTest {
 
         // gitt fakta
         val fakta = Fakta(
-            inntekt = Inntekt("123", emptyList()),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = true,
             fangstOgFisk = false
@@ -32,8 +31,7 @@ internal class InngangsvilkårVernepliktSpesifikasjonsTest {
 
         // gitt fakta
         val fakta = Fakta(
-            inntekt = Inntekt("123", emptyList()),
-            senesteInntektsMåned = YearMonth.of(2019, 4),
+            inntekt = Inntekt("123", emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.of(2019, 4)),
             bruktInntektsPeriode = null,
             verneplikt = false,
             fangstOgFisk = false

--- a/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/MinsteinntektTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/MinsteinntektTopologyTest.kt
@@ -85,7 +85,8 @@ class MinsteinntektTopologyTest {
                     )
 
                 )
-            )
+            ),
+            sisteAvsluttendeKalenderMåned = YearMonth.of(2018, 2)
         )
 
         val json = """
@@ -101,7 +102,8 @@ class MinsteinntektTopologyTest {
             "bruktInntektsPeriode", mapOf(
                 "førsteMåned" to YearMonth.now().toString(),
                 "sisteMåned" to YearMonth.now().toString()
-            ))
+            )
+        )
 
         TopologyTestDriver(minsteinntekt.buildTopology(), config).use { topologyTestDriver ->
             val inputRecord = factory.create(packet)
@@ -114,12 +116,18 @@ class MinsteinntektTopologyTest {
             )
 
             assertTrue { ut.value().hasField(Minsteinntekt.MINSTEINNTEKT_RESULTAT) }
-            assertEquals("Minsteinntekt.v1", ut.value().getMapValue(Minsteinntekt.MINSTEINNTEKT_RESULTAT)[MinsteinntektSubsumsjon.REGELIDENTIFIKATOR])
+            assertEquals(
+                "Minsteinntekt.v1",
+                ut.value().getMapValue(Minsteinntekt.MINSTEINNTEKT_RESULTAT)[MinsteinntektSubsumsjon.REGELIDENTIFIKATOR]
+            )
 
             // test inntektsperioder are added to packet correctly
-            val inntektsPerioder = ut.value().getNullableObjectValue(Minsteinntekt.MINSTEINNTEKT_INNTEKTSPERIODER, minsteinntekt.jsonAdapterInntektPeriodeInfo::fromJsonValue) as List<InntektPeriodeInfo>
+            val inntektsPerioder = ut.value().getNullableObjectValue(
+                Minsteinntekt.MINSTEINNTEKT_INNTEKTSPERIODER,
+                minsteinntekt.jsonAdapterInntektPeriodeInfo::fromJsonValue
+            ) as List<InntektPeriodeInfo>
             assertEquals(3, inntektsPerioder.size)
-            assertEquals(YearMonth.of(2018, 3), inntektsPerioder.find { it.periode == 1 }?.inntektsPeriode?.sisteMåned)
+            assertEquals(YearMonth.of(2018, 2), inntektsPerioder.find { it.periode == 1 }?.inntektsPeriode?.sisteMåned)
             assertEquals(BigDecimal(25000), inntektsPerioder.find { it.periode == 1 }?.inntekt)
         }
     }
@@ -149,12 +157,12 @@ class MinsteinntektTopologyTest {
                         )
                     )
                 )
-            )
+            ),
+            sisteAvsluttendeKalenderMåned = YearMonth.of(2018, 3)
         )
 
         val json = """
         {
-            "senesteInntektsmåned":"2018-03",
             "harAvtjentVerneplikt": true,
             "oppfyllerKravTilFangstOgFisk": true
         }""".trimIndent()
@@ -165,7 +173,8 @@ class MinsteinntektTopologyTest {
             "bruktInntektsPeriode", mapOf(
                 "førsteMåned" to YearMonth.now().toString(),
                 "sisteMåned" to YearMonth.now().toString()
-            ))
+            )
+        )
 
         TopologyTestDriver(minsteinntekt.buildTopology(), config).use { topologyTestDriver ->
             val inputRecord = factory.create(packet)
@@ -178,7 +187,10 @@ class MinsteinntektTopologyTest {
             )
 
             // test inntektsperioder are added to packet correctly
-            val inntektsPerioder = ut.value().getNullableObjectValue(Minsteinntekt.MINSTEINNTEKT_INNTEKTSPERIODER, minsteinntekt.jsonAdapterInntektPeriodeInfo::fromJsonValue) as List<InntektPeriodeInfo>
+            val inntektsPerioder = ut.value().getNullableObjectValue(
+                Minsteinntekt.MINSTEINNTEKT_INNTEKTSPERIODER,
+                minsteinntekt.jsonAdapterInntektPeriodeInfo::fromJsonValue
+            ) as List<InntektPeriodeInfo>
             assertEquals(3, inntektsPerioder.size)
             assertEquals(YearMonth.of(2018, 3), inntektsPerioder.find { it.periode == 1 }?.inntektsPeriode?.sisteMåned)
             assertEquals(BigDecimal(26000), inntektsPerioder.find { it.periode == 1 }?.inntekt)
@@ -194,10 +206,11 @@ class MinsteinntektTopologyTest {
             )
         )
 
-        val inntekt = Inntekt(inntektsId = "12345", inntektsListe = emptyList())
+        val inntekt =
+            Inntekt(inntektsId = "12345", inntektsListe = emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.now())
 
         val packet = Packet()
-        packet.putValue("senesteInntektsmåned", "ERROR")
+        packet.putValue("oppfyllerKravTilFangstOgFisk", "ERROR")
         packet.putValue("inntektV1", jsonAdapterInntekt.toJsonValue(inntekt)!!)
 
         TopologyTestDriver(minsteinntekt.buildTopology(), config).use { topologyTestDriver ->

--- a/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/MinsteinntektTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/MinsteinntektTopologyTest.kt
@@ -37,7 +37,7 @@ class MinsteinntektTopologyTest {
     }
 
     @Test
-    fun ` dagpengebehov without inntekt and senesteinntektsmåned should not be processed`() {
+    fun ` dagpengebehov without inntekt should not be processed`() {
         val minsteinntekt = Minsteinntekt(
             Environment(
                 username = "bogus",
@@ -91,7 +91,6 @@ class MinsteinntektTopologyTest {
 
         val json = """
         {
-            "senesteInntektsmåned":"2018-03",
             "harAvtjentVerneplikt": true,
             "oppfyllerKravTilFangstOgFisk": false
         }""".trimIndent()

--- a/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/PacketToFaktaTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/PacketToFaktaTest.kt
@@ -11,14 +11,14 @@ class PacketToFaktaTest {
 
     val emptyInntekt: Inntekt = Inntekt(
         inntektsId = "12345",
-        inntektsListe = emptyList()
+        inntektsListe = emptyList(),
+        sisteAvsluttendeKalenderMåned = YearMonth.now()
     )
 
     @Test
     fun ` should map fangst_og_fisk from packet to Fakta `() {
         val json = """
         {
-            "senesteInntektsmåned":"2018-03",
             "oppfyllerKravTilFangstOgFisk": true
         }""".trimIndent()
 
@@ -34,7 +34,6 @@ class PacketToFaktaTest {
     fun ` should map avtjent_verneplikt from packet to Fakta `() {
         val json = """
         {
-            "senesteInntektsmåned":"2018-03",
             "harAvtjentVerneplikt": true
         }""".trimIndent()
 
@@ -50,7 +49,6 @@ class PacketToFaktaTest {
     fun ` should map brukt_inntektsperiode from packet to Fakta `() {
         val json = """
         {
-            "senesteInntektsmåned":"2018-03",
             "bruktInntektsPeriode": {"førsteMåned":"2019-02", "sisteMåned":"2019-03"}
         }""".trimIndent()
 
@@ -67,7 +65,6 @@ class PacketToFaktaTest {
     fun ` should map inntekt from packet to Fakta `() {
         val json = """
         {
-            "senesteInntektsmåned":"2018-03"
         }""".trimIndent()
 
         val packet = Packet(json)
@@ -76,20 +73,5 @@ class PacketToFaktaTest {
         val fakta = packetToFakta(packet)
 
         assertEquals("12345", fakta.inntekt.inntektsId)
-    }
-
-    @Test
-    fun ` should map seneste_inntektsmåned from packet to Fakta `() {
-        val json = """
-        {
-            "senesteInntektsmåned":"2018-03"
-        }""".trimIndent()
-
-        val packet = Packet(json)
-        packet.putValue("inntektV1", MinsteinntektTopologyTest.jsonAdapterInntekt.toJsonValue(emptyInntekt)!!)
-
-        val fakta = packetToFakta(packet)
-
-        assertEquals(YearMonth.of(2018, 3), fakta.senesteInntektsMåned)
     }
 }


### PR DESCRIPTION
…es 'senesteInnteksMåned'

- update to new dapgenger-events version