### PR TITLE
Avvikling av avmodningsvedtak 3 - særregel for beregning av minstekra…

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/regel/minsteinntekt/Fakta.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/minsteinntekt/Fakta.kt
@@ -52,4 +52,4 @@ internal fun isThisGjusteringTest(
     return config.features.gjustering() && isBeregningsDatoAfterGjustering
 }
 
-fun LocalDate.erKoronaPeriode() = this in (LocalDate.of(2020, 3, 20)..LocalDate.of(2020, 12, 31))
+fun LocalDate.erKoronaPeriode() = this in (LocalDate.of(2020, 3, 20)..LocalDate.of(2020, 10, 31))

--- a/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/PacketToFaktaTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/minsteinntekt/PacketToFaktaTest.kt
@@ -1,5 +1,10 @@
 package no.nav.dagpenger.regel.minsteinntekt
 
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.data.headers
+import io.kotest.data.row
+import io.kotest.data.table
+import io.kotest.matchers.shouldBe
 import no.nav.dagpenger.events.Packet
 import no.nav.dagpenger.events.inntekt.v1.Inntekt
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -142,3 +147,19 @@ class PacketToFaktaTest {
         assertTrue(fakta.lærling)
     }
 }
+
+class KoronaRegelverkPeriodeTest : FreeSpec({
+    "sjekke grenseverdiene for koronaperiode " {
+        io.kotest.data.forAll(
+            table(
+                headers("dato", "er korona periode ?"),
+                row(LocalDate.of(2020, 3, 19), false),
+                row(LocalDate.of(2020, 3, 20), true),
+                row(LocalDate.of(2020, 10, 31), true),
+                row(LocalDate.of(2020, 11, 1), false),
+            )
+        ) { dato: LocalDate, erKoronaPeriode: Boolean ->
+            dato.erKoronaPeriode() shouldBe erKoronaPeriode
+        }
+    }
+})


### PR DESCRIPTION
…vet.

Minstekravet ble fra 20.03.2020 endret til å være:

0,75 ganger grunnbeløpet siste 12 måneder, eller
2,25 ganger grunnbeløpet siste 36 måneder før kravdato
Dette skal fra 01.11.2020 endres tilbake til de opprinnelige grensene.

closes navikt/dagpenger#564